### PR TITLE
(master) Add set_zero method for GridBase derivative with standard layout cells

### DIFF
--- a/include/grid.h
+++ b/include/grid.h
@@ -1,15 +1,15 @@
 /**
- * @copyright 2018-2019 TwoD
+ * @copyright 2018-2020 TwoD
  * @author Brian Cairl
  *
  * @file grid.h
- * @brief Grid container and view implementations
  */
 #ifndef TWOD_GRID_H
 #define TWOD_GRID_H
 
 // C++ Standard Library
 #include <array>
+#include <cstring>
 #include <memory>
 #include <type_traits>
 #include <utility>
@@ -87,6 +87,21 @@ public:
    * @return view
    */
   inline auto view() const { return view(bounds()); }
+
+  /**
+   * @brief Zeros out grid memory for grids with standard-layout cell types
+   *
+   * @tparam OtherDerivedT  CRTP-derived <code>GridBase</code> object
+   *
+   * @param other  other grid
+   * @return <code>*this</code>
+   */
+  inline void set_zero()
+  {
+    using CellType = cell_t<DerivedT>;
+    static_assert(std::is_standard_layout<CellType>(), "Cell type must be standard-layout to use set_zero()");
+    std::memset(this->derived()->data(), 0, sizeof(CellType) * this->derived()->extents().area());
+  }
 
   /**
    * @brief Generic assignment from <code>GridBase</code> derivative

--- a/include/grid.h
+++ b/include/grid.h
@@ -599,32 +599,34 @@ class Grid : public GridBase<Grid<CellT, AllocatorT>>, public RawAccessBase<Grid
 public:
   Grid() : GridBaseType{Extents::Zero()}, StorageBaseType{nullptr} {}
 
-  explicit Grid(const Extents& extents) : GridBaseType{extents}, StorageBaseType{allocator_.allocate(extents.area())}
+  explicit Grid(const Extents& extents) :
+      GridBaseType{Extents::Zero()},
+      StorageBaseType{nullptr}
   {
-    construct();
+    resize(extents);
   }
 
   Grid(const Extents& extents, const CellT& val) :
-      GridBaseType{extents},
-      StorageBaseType{allocator_.allocate(extents.area())}
+      GridBaseType{Extents::Zero()},
+      StorageBaseType{nullptr}
   {
-    construct(val);
+    resize(extents, val);
   }
 
   Grid(const Extents& extents, const AllocatorT& alloc) :
-      GridBaseType{extents},
-      StorageBaseType{alloc.allocate(extents.area())},
+      GridBaseType{Extents::Zero()},
+      StorageBaseType{nullptr},
       allocator_{alloc}
   {
-    construct();
+    resize(extents);
   }
 
   Grid(const Extents& extents, const CellT& val, const AllocatorT& alloc) :
-      GridBaseType{extents},
-      StorageBaseType{alloc.allocate(extents.area())},
+      GridBaseType{Extents::Zero()},
+      StorageBaseType{nullptr},
       allocator_{alloc}
   {
-    construct(val);
+    resize(extents, val);
   }
 
   Grid(const Grid& other) : Grid{} { Grid::operator=(other); }
@@ -693,10 +695,14 @@ public:
 
   inline Grid& operator=(Grid&& other)
   {
+    // Do a swap on move so that "other" cleans up data previously in *this
+    auto* swap_data =  Grid::data_;
+    const auto swap_extents =  other.extents();
+
     GridBaseType::set_extents(other.extents());
     Grid::data_ = other.data_;
-    other.data_ = nullptr;
-    other.set_extents(Extents::Zero());
+    other.data_ = swap_data;
+    other.set_extents(swap_extents);
     return *this;
   }
 

--- a/test/grid.cpp
+++ b/test/grid.cpp
@@ -129,8 +129,8 @@ TEST(Grid, MoveConstructor)
 
   Grid<int> grid{std::move(initial_grid)};
 
-  ASSERT_EQ(initial_grid.data(), nullptr);
-  ASSERT_EQ(initial_grid.extents(), Extents::Zero());
+  // Does a swap on move, but "initial_grid" should still be treated as invalid
+  // grid <--> initial_grid
 
   ASSERT_EQ(grid.extents(), (Extents{20, 10}));
   ASSERT_FALSE(grid.empty());
@@ -142,7 +142,7 @@ TEST(Grid, MoveConstructor)
 }
 
 
-TEST(Grid, ModeConstructorEmpty)
+TEST(Grid, MoveConstructorEmpty)
 {
   Grid<int> empty_grid;
 
@@ -226,8 +226,8 @@ TEST(Grid, MoveAssignment)
 
   grid = std::move(initial_grid);
 
-  ASSERT_EQ(initial_grid.data(), nullptr);
-  ASSERT_EQ(initial_grid.extents(), Extents::Zero());
+  // Does a swap on move, but "initial_grid" should still be treated as invalid
+  // grid <--> initial_grid
 
   ASSERT_EQ(grid.extents(), (Extents{20, 10}));
   ASSERT_FALSE(grid.empty());

--- a/test/grid.cpp
+++ b/test/grid.cpp
@@ -1,5 +1,5 @@
 /**
- * @copyright 2018 TwoD
+ * @copyright 2018-2020 TwoD
  * @author Brian Cairl
  */
 
@@ -50,6 +50,25 @@ TEST(Grid, UniformInitialValueConstructor)
   }
 }
 
+TEST(Grid, SetZeroIntCell)
+{
+  Grid<int> grid{Extents{20, 10}, 1};
+  grid.set_zero();
+  for (const auto& v : grid)
+  {
+    ASSERT_EQ(v, 0);
+  }
+}
+
+TEST(Grid, SetZeroFloatCell)
+{
+  Grid<float> grid{Extents{20, 10}, 1.f};
+  grid.set_zero();
+  for (const auto& v : grid)
+  {
+    ASSERT_EQ(v, 0.f);
+  }
+}
 
 TEST(Grid, CopyConstructor)
 {

--- a/test/mapped_grid.cpp
+++ b/test/mapped_grid.cpp
@@ -22,7 +22,7 @@ TEST(MappedGrid, InitSizeConstructor)
 {
   constexpr Extents extents{20, 10};
 
-  std::unique_ptr<int> block{new int[extents.area()]};
+  std::unique_ptr<int[]> block{new int[extents.area()]};
 
   MappedGrid<int> grid{extents, block.get()};
 
@@ -35,7 +35,7 @@ TEST(MappedGrid, CopyConstructor)
 {
   constexpr Extents extents{20, 10};
 
-  std::unique_ptr<int> block{new int[extents.area()]};
+  std::unique_ptr<int[]> block{new int[extents.area()]};
 
   std::fill(block.get(), block.get() + extents.area(), 1);
 
@@ -67,7 +67,7 @@ TEST(MappedGrid, CopyAssignment)
 {
   constexpr Extents extents{20, 10};
 
-  std::unique_ptr<int> block{new int[extents.area()]};
+  std::unique_ptr<int[]> block{new int[extents.area()]};
 
   std::fill(block.get(), block.get() + extents.area(), 1);
 
@@ -101,7 +101,7 @@ TEST(MappedGrid, Swap)
 {
   constexpr Extents extents{20, 10};
 
-  std::unique_ptr<int> block{new int[extents.area()]};
+  std::unique_ptr<int[]> block{new int[extents.area()]};
 
   std::fill(block.get(), block.get() + extents.area(), 1);
 
@@ -139,7 +139,7 @@ TEST(MappedGrid, ColViewIterator)
 {
   constexpr Extents extents{20, 10};
 
-  std::unique_ptr<int> block{new int[extents.area()]};
+  std::unique_ptr<int[]> block{new int[extents.area()]};
 
   std::fill(block.get(), block.get() + extents.area(), 1);
 
@@ -167,7 +167,7 @@ TEST(MappedGrid, ColViewIteratorEndTag)
 {
   constexpr Extents extents{20, 10};
 
-  std::unique_ptr<int> block{new int[extents.area()]};
+  std::unique_ptr<int[]> block{new int[extents.area()]};
 
   MappedGrid<int> grid{extents, block.get()};
   ASSERT_EQ(grid.extents(), extents);
@@ -190,7 +190,7 @@ TEST(MappedGrid, RowViewIterator)
 {
   constexpr Extents extents{20, 10};
 
-  std::unique_ptr<int> block{new int[extents.area()]};
+  std::unique_ptr<int[]> block{new int[extents.area()]};
 
   MappedGrid<int> grid{extents, block.get()};
   ASSERT_EQ(grid.extents(), extents);
@@ -216,7 +216,7 @@ TEST(MappedGrid, RowViewIteratorEndTag)
 {
   constexpr Extents extents{20, 10};
 
-  std::unique_ptr<int> block{new int[extents.area()]};
+  std::unique_ptr<int[]> block{new int[extents.area()]};
 
   MappedGrid<int> grid{extents, block.get()};
   ASSERT_EQ(grid.extents(), extents);
@@ -239,7 +239,7 @@ TEST(MappedGrid, ViewBoundsIteration)
 {
   constexpr Extents extents{20, 10};
 
-  std::unique_ptr<int> block{new int[extents.area()]};
+  std::unique_ptr<int[]> block{new int[extents.area()]};
 
   MappedGrid<int> grid{extents, block.get()};
   ASSERT_EQ(grid.extents(), extents);


### PR DESCRIPTION
- Adds std::memset under the hood